### PR TITLE
chore: fix vite peerDeps range to `>=3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vitest": "1.6.0"
   },
   "peerDependencies": {
-    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+    "vite": ">=3.0.0"
   },
   "lint-staged": {
     "*": [


### PR DESCRIPTION
close: #98
